### PR TITLE
Force Cim classes to register

### DIFF
--- a/Tests/MSFT_xWebBindingInformation.Tests.ps1
+++ b/Tests/MSFT_xWebBindingInformation.Tests.ps1
@@ -9,6 +9,35 @@ if($env:APPVEYOR_BUILD_VERSION)
 Import-Module (Join-Path $here -ChildPath "..\DSCResources\MSFT_xWebsite\MSFT_xWebsite.psm1")
 
 Describe "MSFT_xWebBindingInformation" {
+    It 'Should be able to get xWebsite' -test {
+        # just a good idea.  
+        # I thought it might force the classes to register, but it does not.
+        $resources = Get-DscResource -Name xWebsite
+        $resources.count | should be 1
+    }
+
+    It 'Should compile and run without throwing' -test {
+        {
+        # Force Cim Classes to register
+        # Update the system environment path so that LCM will load the module
+        # Requires WMF 5
+        [System.Environment]::SetEnvironmentVariable('PSModulePath',$env:PSModulePath,[System.EnvironmentVariableTarget]::Machine)
+        configuration foo
+        {
+            Import-DscResource -ModuleName xWebAdministration
+
+            xWebsite foo
+            {
+                Name = 'foobar'
+                Ensure = 'absent'
+            }
+        }
+
+        foo -OutputPath $env:temp\foo
+        Start-DscConfiguration -Path $env:temp\foo -Wait -Verbose -ErrorAction Stop} | should not throw
+    }
+    
+    $xWebBindingInforationClass = (Get-CimClass -Namespace "root/microsoft/Windows/DesiredStateConfiguration" -ClassName "MSFT_xWebBindingInformation")
     $storeNames = (Get-CimClass -Namespace "root/microsoft/Windows/DesiredStateConfiguration" -ClassName "MSFT_xWebBindingInformation").CimClassProperties['CertificateStoreName'].Qualifiers['Values'].Value
     foreach ($storeName in $storeNames){
         It "Uses valid credential store: $storeName" {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+os: unstable  
 install: 
     - cinst -y pester
     - git clone https://github.com/PowerShell/DscResource.Tests
@@ -7,7 +8,10 @@ build: false
 test_script:
     - ps: |
         $testResultsFile = ".\TestsResults.xml"
+        $tempModulePath = (Resolve-Path (join-path $PWD '..')).ProviderPath
+        $env:PSModulePath = "$env:PSModulePath;$tempModulePath"      
         $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
+
         (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
         if ($res.FailedCount -gt 0) { 
             throw "$($res.FailedCount) tests failed."


### PR DESCRIPTION
Add os: unstable to appveyor.yml to use WMF 5.  Required for LCM to update the module path without a reboot.

Update the PSModulePath before running the test so we can use the module in the powershell DSC language and in LCM.

Added a test which run a configuration using xWebsite.  This will register the CIM class ( this test is registering the CIM class, but failing because the resource is calling something interactive.)
